### PR TITLE
Yaml Cmake python executable change

### DIFF
--- a/vehicles/config/CMakeLists.txt
+++ b/vehicles/config/CMakeLists.txt
@@ -18,6 +18,9 @@
 #                                                                        #
 # ---------------------------------------------------------------------- #
 
+# find python3 executable
+find_package(Python3 COMPONENTS Interpreter REQUIRED)
+
 # include all yaml files as dependence
 file(GLOB_RECURSE YAML_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.yaml)
 
@@ -31,8 +34,7 @@ string(REGEX MATCHALL "[A-Za-z0-9/_]*.yaml" yaml_file_list ${yaml_list})
 #message("${yaml_file_list}")
 
 add_custom_target(yaml_headers
-    COMMAND python generate_all.py yaml_list
+    COMMAND ${Python3_EXECUTABLE} generate_all.py yaml_list
     WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
     DEPENDS ${YAML_FILES}
     )
-


### PR DESCRIPTION
Because some Linux version would have their python 3 executable named `python3` instead of `python`, so command used to generate headers is changed from evoking hard-coded `python` to evoking executable found by Cmake facility `find_package`.