### PR TITLE
Custom (Output constrainted) PID

### DIFF
--- a/examples/motor/CMakeLists.txt
+++ b/examples/motor/CMakeLists.txt
@@ -28,6 +28,10 @@ irm_add_arm_executable(${PROJECT_NAME}_m3508_speed
     TARGET DJI_Board_TypeA
     SOURCES m3508_speed.cc)
 
+irm_add_arm_executable(${PROJECT_NAME}_m3508_output_constraint
+    TARGET DJI_Board_TypeA
+    SOURCES m3508_output_constraint.cc)
+
 irm_add_arm_executable(${PROJECT_NAME}_m3508_position
     TARGET DJI_Board_TypeA
     SOURCES m3508_position.cc)

--- a/examples/motor/m3508_output_constraint.cc
+++ b/examples/motor/m3508_output_constraint.cc
@@ -22,8 +22,8 @@
 #include "cmsis_os.h"
 #include "controller.h"
 #include "main.h"
-#include "utils.h"
 #include "motor.h"
+#include "utils.h"
 
 #define KEY_GPIO_GROUP GPIOB
 #define KEY_GPIO_PIN GPIO_PIN_2
@@ -64,10 +64,12 @@ void RM_RTOS_Default_Task(const void* args) {
       use_constrainted_pid = !use_constrainted_pid;
     }
 
-    if (use_constrainted_pid) motor->SetOutput(out2);
-    else motor->SetOutput(out1);
+    if (use_constrainted_pid)
+      motor->SetOutput(out2);
+    else
+      motor->SetOutput(out1);
     control::MotorCANBase::TransmitOutput(motors, 1);
-    
+
     print("% 10d % 10d % 10d\r\n", out1, out2, out1 - out2);
     osDelay(10);
   }

--- a/examples/motor/m3508_output_constraint.cc
+++ b/examples/motor/m3508_output_constraint.cc
@@ -1,0 +1,74 @@
+/****************************************************************************
+ *                                                                          *
+ *  Copyright (C) 2022 RoboMaster.                                          *
+ *  Illini RoboMaster @ University of Illinois at Urbana-Champaign          *
+ *                                                                          *
+ *  This program is free software: you can redistribute it and/or modify    *
+ *  it under the terms of the GNU General Public License as published by    *
+ *  the Free Software Foundation, either version 3 of the License, or       *
+ *  (at your option) any later version.                                     *
+ *                                                                          *
+ *  This program is distributed in the hope that it will be useful,         *
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of          *
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the           *
+ *  GNU General Public License for more details.                            *
+ *                                                                          *
+ *  You should have received a copy of the GNU General Public License       *
+ *  along with this program. If not, see <http://www.gnu.org/licenses/>.    *
+ *                                                                          *
+ ****************************************************************************/
+
+#include "bsp_gpio.h"
+#include "cmsis_os.h"
+#include "controller.h"
+#include "main.h"
+#include "utils.h"
+#include "motor.h"
+
+#define KEY_GPIO_GROUP GPIOB
+#define KEY_GPIO_PIN GPIO_PIN_2
+BoolEdgeDetector key_detect(false);
+
+#define TARGET_SPEED 80
+
+bsp::CAN* can1 = nullptr;
+control::MotorCANBase* motor = nullptr;
+
+control::PIDController pid1;
+control::OutputConstraintedPIDController pid2;
+
+void RM_RTOS_Init(void) {
+  print_use_uart(&huart8);
+
+  can1 = new bsp::CAN(&hcan1, 0x201);
+  motor = new control::Motor3508(can1, 0x201);
+
+  float* pid_param = new float[3]{20, 15, 30};
+  pid1.Reinit(pid_param);
+  pid2.Reinit(pid_param);
+}
+
+void RM_RTOS_Default_Task(const void* args) {
+  UNUSED(args);
+  bsp::GPIO key(KEY_GPIO_GROUP, KEY_GPIO_PIN);
+  control::MotorCANBase* motors[] = {motor};
+  bool use_constrainted_pid = false;
+
+  while (true) {
+    float err = motor->GetOmegaDelta(TARGET_SPEED);
+    int out1 = pid1.ComputeConstraintedOutput(err);
+    int out2 = pid2.ComputeOutput(err, 32767);
+
+    key_detect.input(key.Read());
+    if (key_detect.posEdge()) {
+      use_constrainted_pid = !use_constrainted_pid;
+    }
+
+    if (use_constrainted_pid) motor->SetOutput(out2);
+    else motor->SetOutput(out1);
+    control::MotorCANBase::TransmitOutput(motors, 1);
+    
+    print("% 10d % 10d % 10d\r\n", out1, out2, out1 - out2);
+    osDelay(10);
+  }
+}

--- a/shared/libraries/chassis.cc
+++ b/shared/libraries/chassis.cc
@@ -100,7 +100,8 @@ void Chassis::Update() {
       float k = requested_current > CURRENT_MAX ? CURRENT_MAX / requested_current : 1;
       print("% 7.5f % 7.5f \r\n", requested_current, k);
       for (int i = 0; i < FourWheel::motor_num; i++) {
-        motors_[i]->SetOutput(pids_[i].ComputeOutput(motors_[i]->GetOmegaDelta(speeds_[i]), k * abs(outputs[i])));
+        motors_[i]->SetOutput(
+            pids_[i].ComputeOutput(motors_[i]->GetOmegaDelta(speeds_[i]), k * abs(outputs[i])));
       }
       break;
   }

--- a/shared/libraries/chassis.h
+++ b/shared/libraries/chassis.h
@@ -85,7 +85,7 @@ class Chassis {
   chassis_model_t model_;
 
   // pids and current speeds for each motor on the chassis
-  PIDController pids_[MAX_WHEEL_NUM];
+  OutputConstraintedPIDController pids_[MAX_WHEEL_NUM];
   float* speeds_;
 };
 

--- a/shared/libraries/controller.cc
+++ b/shared/libraries/controller.cc
@@ -19,8 +19,8 @@
  ****************************************************************************/
 
 #include "controller.h"
-#include "bsp_error_handler.h"
 
+#include "bsp_error_handler.h"
 #include "utils.h"
 
 namespace control {

--- a/shared/libraries/controller.cc
+++ b/shared/libraries/controller.cc
@@ -54,9 +54,9 @@ int16_t PIDController::ComputeConstraintedOutput(float error) {
    * of the output computation can make sure that no unexpected behavior (overflow)
    * can happen.
    */
-  constexpr int MIN = -32768; /* Minimum that a 16-bit number can represent */
-  constexpr int MAX = 32767;  /* Maximum that a 16-bit number can represent */
-  return clip<int>((int)arm_pid_f32(&pid_f32_, error), MIN, MAX);
+  constexpr int MOTOR_MIN = -32768; /* Minimum that a 16-bit number can represent */
+  constexpr int MOTOR_MAX = 32767;  /* Maximum that a 16-bit number can represent */
+  return clip<int>((int)arm_pid_f32(&pid_f32_, error), MOTOR_MIN, MOTOR_MAX);
 }
 
 void PIDController::Reinit(float kp, float ki, float kd) {
@@ -68,6 +68,49 @@ void PIDController::Reinit(float kp, float ki, float kd) {
 
 void PIDController::Reinit(float* param) { Reinit(param[0], param[1], param[2]); }
 
-void PIDController::Reset() { arm_pid_init_f32(&pid_f32_, 1); }
+void PIDController::Reset() { arm_pid_reset_f32(&pid_f32_); }
+
+OutputConstraintedPIDController::OutputConstraintedPIDController() {
+  Reinit(0 ,0, 0);
+  Reset();
+}
+
+OutputConstraintedPIDController::OutputConstraintedPIDController(float kp, float ki, float kd) {
+  Reinit(kp, ki, kd);
+  Reset();
+}
+
+OutputConstraintedPIDController::OutputConstraintedPIDController(float* param) {
+  Reinit(param[0], param[1], param[2]);
+  Reset();
+}
+
+float OutputConstraintedPIDController::ComputeOutput(float error, int max_out) {
+  constexpr int MOTOR_MAX = 32767;
+  max_out = clip<float>(max_out, 0, MOTOR_MAX);
+  float bias = ki_ * cumulated_err_ - kd_ * last_err_;
+  float error_max = (max_out - bias) / param_sum_;
+  float error_min = (-max_out - bias) / param_sum_;
+  error = clip<float>(error, error_min, error_max);
+
+  cumulated_err_ += error;
+  float out = kp_ * error + ki_ * cumulated_err_ + kd_ * (error - last_err_);
+  last_err_ = error;
+  return out;
+}
+
+void OutputConstraintedPIDController::Reinit(float kp, float ki, float kd) {
+  kp_ = kp;
+  ki_ = ki;
+  kd_ = kd;
+  param_sum_ = kp_ + ki_ + kd_;
+}
+
+void OutputConstraintedPIDController::Reinit(float* param) { Reinit(param[0], param[1], param[2]); }
+
+void OutputConstraintedPIDController::Reset() {
+  cumulated_err_ = 0;
+  last_err_ = 0;
+}
 
 } /* namespace control */

--- a/shared/libraries/controller.cc
+++ b/shared/libraries/controller.cc
@@ -99,6 +99,10 @@ float OutputConstraintedPIDController::ComputeOutput(float error, int max_out) {
   return out;
 }
 
+float OutputConstraintedPIDController::TryComputeOutput(float error) {
+  return kp_ * error + ki_ * (cumulated_err_ + error) + kd_ * (error - last_err_);
+}
+
 void OutputConstraintedPIDController::Reinit(float kp, float ki, float kd) {
   kp_ = kp;
   ki_ = ki;

--- a/shared/libraries/controller.cc
+++ b/shared/libraries/controller.cc
@@ -71,7 +71,7 @@ void PIDController::Reinit(float* param) { Reinit(param[0], param[1], param[2]);
 void PIDController::Reset() { arm_pid_reset_f32(&pid_f32_); }
 
 OutputConstraintedPIDController::OutputConstraintedPIDController() {
-  Reinit(0 ,0, 0);
+  Reinit(0, 0, 0);
   Reset();
 }
 

--- a/shared/libraries/controller.cc
+++ b/shared/libraries/controller.cc
@@ -19,6 +19,7 @@
  ****************************************************************************/
 
 #include "controller.h"
+#include "bsp_error_handler.h"
 
 #include "utils.h"
 
@@ -96,6 +97,7 @@ float OutputConstraintedPIDController::ComputeOutput(float error, int max_out) {
   cumulated_err_ += error;
   float out = kp_ * error + ki_ * cumulated_err_ + kd_ * (error - last_err_);
   last_err_ = error;
+  print(" % 10.4f ", out);
   return out;
 }
 

--- a/shared/libraries/controller.h
+++ b/shared/libraries/controller.h
@@ -137,7 +137,7 @@ class OutputConstraintedPIDController {
 
   /**
    * @brief try to compute the control command
-   * 
+   *
    * @param error error of the system, i.e. (target - actual)
    * @return output value that could potentially drive the error to 0, will not be clamped
    */

--- a/shared/libraries/controller.h
+++ b/shared/libraries/controller.h
@@ -102,4 +102,69 @@ class PIDController {
   arm_pid_instance_f32 pid_f32_;
 };
 
+class OutputConstraintedPIDController {
+ public:
+  /**
+   * @brief PID controller default constructor
+   */
+  OutputConstraintedPIDController();
+
+  /**
+   * @brief PID controller constructor
+   *
+   * @param kp proportional gain
+   * @param ki integral gain
+   * @param kd derivative gain
+   */
+  OutputConstraintedPIDController(float kp, float ki, float kd);
+
+  /**
+   * @brief PID controller constructor
+   *
+   * @param param gains of PID controller, formated as [kp, ki, kd]
+   */
+  OutputConstraintedPIDController(float* param);
+
+  /**
+   * @brief compute output base on current error
+   *
+   * @param error error of the system, i.e. (target - actual)
+   *
+   * @return output value that could potentially drive the error to 0
+   */
+  float ComputeOutput(float error, int max_out);
+
+  /**
+   * @brief reinitialize the pid instance using another set of gains, but does not clear
+   *        current status
+   *
+   * @param kp new proportional gain
+   * @param ki new integral gain
+   * @param kd new derivative gain
+   */
+  void Reinit(float kp, float ki, float kd);
+
+  /**
+   * @brief reinitialize the pid instance using another set of gains, but does not clear
+   *        current status
+   *
+   * @param param gains of PID controller, formated as [kp, ki, kd]
+   */
+  void Reinit(float* param);
+
+  /**
+   * @brief clear the remembered states of the controller
+   */
+  void Reset();
+
+ private:
+  float kp_;
+  float ki_;
+  float kd_;
+
+  float last_err_;
+  float cumulated_err_;
+  float param_sum_;
+};
+
 } /* namespace control */

--- a/shared/libraries/controller.h
+++ b/shared/libraries/controller.h
@@ -128,11 +128,20 @@ class OutputConstraintedPIDController {
   /**
    * @brief compute output base on current error
    *
-   * @param error error of the system, i.e. (target - actual)
+   * @param error   error of the system, i.e. (target - actual)
+   * @param max_out maximum output possible for this pid
    *
    * @return output value that could potentially drive the error to 0
    */
   float ComputeOutput(float error, int max_out);
+
+  /**
+   * @brief try to compute the control command
+   * 
+   * @param error error of the system, i.e. (target - actual)
+   * @return output value that could potentially drive the error to 0, will not be clamped
+   */
+  float TryComputeOutput(float error);
 
   /**
    * @brief reinitialize the pid instance using another set of gains, but does not clear


### PR DESCRIPTION
Custom PID class finished, it have the ability of constraining the output using user specified ceiling. Internal state controllable,  

* Notice: Due to the nature of ARM PID calculator, the `PIDController` class cannot be allocated using `new`, so class inheritance and polymorphism can not and is not used. This should be fixed somehow although I did not think of a good solution.
* Notice: During development, I found out ARM PID controller can sometimes be allocated using `new` without triggering hard fault handler, actual reason to be investigated.